### PR TITLE
Make discogstagger3 work with the current discogs image API

### DIFF
--- a/discogstagger/discogsalbum.py
+++ b/discogstagger/discogsalbum.py
@@ -1,8 +1,7 @@
 import logging
 import re
 import os
-import urllib
-import urllib.request
+from urllib.request import urlopen, Request
 import string
 
 import pprint
@@ -179,7 +178,12 @@ class DiscogsConnector(object):
         # rl.lastcall = time.time()
 
         try:
-            urllib.request.urlretrieve(image_url,  image_dir)
+            req = Request(image_url, headers={'User-Agent': self.user_agent})
+            response = urlopen(req)
+            image = response.read()
+
+            with open(image_dir, "wb") as file:
+                file.write(image)
             # urllib.urlretrieve(image_url,  image_dir)
 
             # self.rate_limit_pool[rate_limit_type] = rl

--- a/discogstagger/discogsalbum.py
+++ b/discogstagger/discogsalbum.py
@@ -255,7 +255,7 @@ class LocalDiscogsConnector(object):
         """ This is an exact copy of a method in _common_test, please refactor
         """
         if isinstance(input, dict):
-            return {self.convert(key): self.convert(value) for key, value in input.iteritems()}
+            return {self.convert(key): self.convert(value) for key, value in input.items()}
         elif isinstance(input, list):
             return [self.convert(element) for element in input]
         # elif isinstance(input, unicode):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mako>=0.8.1
 coverage>=3.6
 invoke==0.7.0
 rauth>=0.6.2
+watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ coverage>=3.6
 invoke==0.7.0
 rauth>=0.6.2
 watchdog
+chardet


### PR DESCRIPTION
It's a bunch of smaller changes required on my end to make your excellent discogstagger3 work for me. The two main things are:

- syntactical differences between python2 and python3
- related to changes done at the discogs API end. It's now required to supply a User-Agent when downloading images.